### PR TITLE
Add Prefect story to index.rst

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,6 +14,7 @@ This page shares stories from other Dask users.
    hydrologic-modeling.md
    network-modeling.md
    satellite-imagery.md
+   prefect-workflows.md
 
 Contributing
 ------------


### PR DESCRIPTION
Currently the "Prefect: Production Workflows" story is not listed at https://stories.dask.org/