### PR TITLE
Use myst-parser instead of recommonmark

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,11 +39,8 @@ release = ''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "myst_parser"
 ]
-
-source_parsers = {
-    '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 
 # Add any paths that contain templates here, relative to this directory.
@@ -52,7 +49,12 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = ['.rst', '.md']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.txt': 'markdown',
+    '.md': 'markdown',
+}
+
 #  source_suffix = '.rst'
 
 # The master toctree document.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-recommonmark
+myst-parser
 sphinx
 dask_sphinx_theme>=2


### PR DESCRIPTION
I noticed markdown files aren't being rendered properly. Sphinx now recommends using `myst-parser` for processing markdown files instead of `recommonmark` (which is now deprecated) https://www.sphinx-doc.org/en/master/usage/markdown.html. This PR updates to using `myst-parser`