### PR TITLE
Update docs theme for rebranding

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,7 +73,9 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'default'
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 myst-parser
 sphinx
-dask_sphinx_theme>=2
+dask-sphinx-theme>=3.0.0


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell